### PR TITLE
Feature: Add "package" install method

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # == Class: traefik
 #
 # [*install_method*]
-#   The installation method to use. Possible values: url, none
+#   The installation method to use. Possible values: url, package, none
 #
 # [*download_url_base*]
 #   The base part of the URL to download Traefik from.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@
 # === Parameters
 #
 # [*install_method*]
-#   The installation method to use. Possible values: url, none
+#   The installation method to use. Possible values: url, package, none
 #
 # [*download_url_base*]
 #   The base part of the URL to download Traefik from.
@@ -41,6 +41,7 @@ class traefik::install (
   $install_method    = $traefik::params::install_method,
 
   $download_url_base = $traefik::params::download_url_base,
+  $package_name      = $traefik::params::package_name,
   $version           = $traefik::params::version,
   $os                = $traefik::params::os,
   $arch              = $traefik::params::arch,
@@ -95,6 +96,11 @@ class traefik::install (
         "${bin_dir}/traefik":
           ensure => link,
           target => "${archive_dir}/traefik-${version}/traefik";
+      }
+    }
+    'package': {
+      package { $package_name:
+        ensure => $version,
       }
     }
     'none': {}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class traefik::params {
   $download_url_base = 'https://github.com/containous/traefik/releases/download'
   $version           = '1.7.18'
   $archive_dir       = '/opt/puppet-archive'
+  $package_name      = 'traefik'
   $bin_dir           = '/usr/local/bin'
   $max_open_files    = 16384
 

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -166,7 +166,6 @@ describe 'traefik::install' do
         end
 
         it { is_expected.to contain_package('traefik-package').with_ensure(version) }
-
       end
 
       describe 'with install_method "none"' do

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -156,6 +156,19 @@ describe 'traefik::install' do
         end
       end
 
+      describe 'with install_method "package"' do
+        let(:params) do
+          {
+            version: version,
+            install_method: 'package',
+            package_name: 'traefik-package',
+          }
+        end
+
+        it { is_expected.to contain_package('traefik-package').with_ensure(version) }
+
+      end
+
       describe 'with install_method "none"' do
         let(:params) do
           {
@@ -189,12 +202,12 @@ describe 'traefik::install' do
       end
 
       describe 'with an unsupported install_method' do
-        let(:params) { { install_method: 'package' } }
+        let(:params) { { install_method: 'rpm' } }
 
         it do
           is_expected.to raise_error(
             Puppet::Error,
-            %r{The provided install method "package" is invalid},
+            %r{The provided install method "rpm" is invalid},
           )
         end
       end


### PR DESCRIPTION
This commit allows for the installation method to be package. Meaning the module can also install a package if one is available instead of having to rely on a download from the interwebz or passing 'none' and having to manage the package install outside the dedicated module.
Signed-off-by: bjanssens <bjanssens@inuits.eu>