### PR TITLE
Allow custom WorkingDirectory for systemd service

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -59,7 +59,7 @@ class traefik::install (
   $init_style        = $traefik::params::init_style,
   $config_path       = undef,
 
-  $systemd_workdir    = $traefik::params::systemd_workdir
+  $systemd_workdir   = $traefik::params::systemd_workdir
 ) inherits traefik::params {
 
   validate_integer($max_open_files)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -37,6 +37,10 @@
 #   The path to the config file that Traefik should load on startup. By default,
 #   Traefik looks in a few places for a config file. This is described in its
 #   documentation.
+#
+# [*systemd_workdir*]
+#   Define the systemd WorkingDirectory for the traefik service.
+#   This allows you to put local plugins in a custom directory.
 class traefik::install (
   $install_method    = $traefik::params::install_method,
 
@@ -54,6 +58,8 @@ class traefik::install (
 
   $init_style        = $traefik::params::init_style,
   $config_path       = undef,
+
+  $systemd_workdir    = $traefik::params::systemd_workdir
 ) inherits traefik::params {
 
   validate_integer($max_open_files)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,8 @@ class traefik::params {
   $config_dir        = '/etc/traefik'
   $config_file       = 'traefik.toml'
 
+  $systemd_workdir   = undef
+
   case $::architecture {
     'x86_64', 'amd64': { $arch = 'amd64' }
     'i386':            { $arch = '386'   }

--- a/templates/traefik.systemd.erb
+++ b/templates/traefik.systemd.erb
@@ -4,6 +4,7 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
+<%- if @systemd_workdir != nil %>WorkingDirectory=<% @systemd_workdir %><% end -%>
 ExecStart=<%= @bin_dir %>/traefik<% if @config_path %> --configFile=<%= @config_path %><% end %>
 Restart=on-failure
 LimitNOFILE=<%= @max_open_files %>


### PR DESCRIPTION
Traefik has a feature to use local plugins since version 2.5.0. These plugins get loaded from the directory where the process is started. When using `systemd`, that's `/` by default. Installing plugins there doesn't seem like the best fit. 

You can define `WorkingDirectory` in a systemd service file. This PR allows you to define a custom `WorkingDirectory`, so you can install the local plugins wherever you'd like.